### PR TITLE
Columns

### DIFF
--- a/app/containers/SearchPage/SearchView.tsx
+++ b/app/containers/SearchPage/SearchView.tsx
@@ -317,7 +317,7 @@ class SearchView extends React.PureComponent<SearchViewProps> {
     return {
       Header: <SearchFieldName field={headerName} />,
       accessor: camelCaseName,
-      Style: {
+      style: {
         overflowWrap: 'break-word',
         overflow: 'hidden',
         whiteSpace: 'normal',

--- a/app/containers/SearchPage/SearchView.tsx
+++ b/app/containers/SearchPage/SearchView.tsx
@@ -326,12 +326,12 @@ class SearchView extends React.PureComponent<SearchViewProps> {
       Cell: !this.isStarColumn(name)
         ? null
         // the stars and the number of reviews. css in global-styles.ts makes it so they're on one line
-        : props => (<div><div id="stars"><ReactStars
+        : props => (<div><div id="divsononeline"><ReactStars
           count={5}
           color2={starColor}
           edit={false}
           value={Number(props.original.averageRating)}/></div>
-          <div id="numreviews">
+          <div id="divsononeline">
             &nbsp;({props.original.reviewsCount})</div>
           </div>),
        width: getColumnWidth(),

--- a/app/containers/SearchPage/SearchView.tsx
+++ b/app/containers/SearchPage/SearchView.tsx
@@ -276,17 +276,50 @@ class SearchView extends React.PureComponent<SearchViewProps> {
     };
   };
 
-  renderColumn = (name: string) => {
+  renderColumn = (name: string, data) => {
     // INPUT: col name
     // OUTPUT render a react-table column with given header, accessor, style,
     // and value determined by studyfragment of that column.
     // also renders stars
+    const camelCaseName = camelCase(name);
+    const lowerCaseSpacing = 8;
+    const upperCaseSpacing = 10;
+    const maxWidth = 400;
+    const totalPadding = 17;
+    const getColumnWidth = () => {
+      if (data.length < 1) {
+        return calcWidth(headerName.split('')) + totalPadding;
+      }
+      
+      let max = headerName;
+      for (let i = 0; i < data.length; i += 1) {
+        const elem = data[i][camelCaseName];
+        if (data[i] !== undefined && elem !== null) {
+          const str = elem.toString();
+          if (str.length > max.length) {
+            max = str;
+          }
+        }
+      }
+      const maxArray = max.split('');
+      let maxSize = Math.max(calcWidth(maxArray), calcWidth(headerName.split('')) + totalPadding);
+      return Math.min(maxWidth, maxSize);
+    };
+
+    const calcWidth = array => {
+      return array.reduce(((acc, letter) =>
+                        letter === letter.toUpperCase() && letter !== ' ' ?
+                          acc + upperCaseSpacing : acc + lowerCaseSpacing),
+                          0);
+    };
+
+    const headerName = COLUMN_NAMES[name];
     return {
-      Header: <SearchFieldName field={COLUMN_NAMES[name]} />,
-      accessor: camelCase(name),
+      Header: <SearchFieldName field={headerName} />,
+      accessor: camelCaseName,
       Style: {
         overflowWrap: 'break-word',
-        overflow: 'visible',
+        overflow: 'hidden',
         whiteSpace: 'normal',
         textAlign: this.isStarColumn(name) ? 'center' : null,
       },
@@ -301,6 +334,8 @@ class SearchView extends React.PureComponent<SearchViewProps> {
           <div id="numreviews">
             &nbsp;({props.original.reviewsCount})</div>
           </div>),
+       width: getColumnWidth(),
+
     };
   };
 
@@ -340,15 +375,24 @@ class SearchView extends React.PureComponent<SearchViewProps> {
     if (loading) {
       return (
         <SiteProvider>
-          {site => (
-            <ReactTable
-              className="-striped -highlight"
-              columns={map(this.renderColumn, site.siteView.search.fields)}
-              manual
-              loading={true}
+          {site => {
+           const columns = map(x=>this.renderColumn(x, ''), site.siteView.search.fields);
+           const totalWidth = columns.reduce(((acc, col)=> acc+col.width), 0);
+           const leftover = tableWidth - totalWidth;
+           const additionalWidth = leftover / columns.length;
+           columns.map(x=>x.width += additionalWidth, columns);
+           return (
+            <ReactTable 
+              className="-striped -highlight" 
+              columns = {columns}
+              manual 
+              loading={true} 
               defaultSortDesc
             />
           )}
+
+          }
+
         </SiteProvider>
       );
     }
@@ -362,40 +406,50 @@ class SearchView extends React.PureComponent<SearchViewProps> {
     const totalPages = Math.ceil(totalRecords / pageSize);
     const idSortedLens = lensProp('id');
     const camelizedSorts = map(over(idSortedLens, camelCase), sorts);
+    const searchData = path(['search', 'studies'], data);
+    const tableWidth = 1140;
+
     return (
       <SiteProvider>
-        {site => (
-          <ReactTable
-            className="-striped -highlight"
-            columns={map(this.renderColumn, site.siteView.search.fields)}
-            manual
-            minRows={1} // this is so it truncates the results when there are less than pageSize results on the page
-            page={page}
-            pageSize={pageSize}
-            defaultSorted={camelizedSorts}
-            onPageChange={pipe(
-              changePage,
-              this.props.onUpdateParams,
-            )}
-            onPageSizeChange={pipe(
-              changePageSize,
-              this.props.onUpdateParams,
-            )}
-            onSortedChange={pipe(
-              changeSorted,
-              this.props.onUpdateParams,
-            )}
-            data={path(['search', 'studies'], data)}
-            pages={totalPages}
-            loading={loading}
-            defaultPageSize={pageSize}
-            getTdProps={this.rowProps}
-            defaultSortDesc
-          />
-        )}
+        {site => {
+         const columns = map(x => this.renderColumn(x, searchData), site.siteView.search.fields);
+         const totalWidth = columns.reduce(((acc, col)=> acc+col.width), 0);
+         const leftover = tableWidth-totalWidth;
+         const additionalWidth=leftover/columns.length;
+         columns.map(x=>x.width+= additionalWidth, columns);
+
+         return (
+           <ReactTable
+             className="-striped -highlight"
+             columns={columns}
+             manual
+             minRows={searchData![0] !== undefined ? 1 : 3}
+             page={page}
+             pageSize={pageSize}
+             defaultSorted={camelizedSorts}
+             onPageChange={pipe(
+               changePage, 
+               this.props.onUpdateParams,)}
+             onPageSizeChange={pipe(
+               changePageSize,
+               this.props.onUpdateParams,)}
+             onSortedChange = {pipe(
+               changeSorted, 
+               this.props.onUpdateParams,)}
+             data={searchData}
+             pages={totalPages}
+             loading={loading}
+             defaultPageSize={pageSize}
+             getTdProps={this.rowProps}
+             defaultSortDesc
+             noDataText={'No studies found'}
+           />
+           );
+        }}
       </SiteProvider>
-    );
+       );
   };
+
 
   renderCrumbs = ({
     data,
@@ -406,7 +460,7 @@ class SearchView extends React.PureComponent<SearchViewProps> {
     loading: boolean;
     error: any;
   }) => {
-    let pagesTotal = 0;
+    let pagesTotal = 1;
     let recordsTotal = 0;
     if (
       data &&

--- a/app/global-styles.ts
+++ b/app/global-styles.ts
@@ -85,12 +85,8 @@ div.DraftEditor-editorContainer{
   font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
-#stars {
-   float: left;
+#divsononeline {
+  display: inline-block;
+  vertical-align: middle;
 }
-
-#numreviews{
-   float: left;
-}
-
 `;


### PR DESCRIPTION
Better formatted table than the one on dev. Decent list of changes to the table:

1) The formatting of the briefTitles on studies has wordWrap again 
![image](https://user-images.githubusercontent.com/14948338/62120565-b1c6ed80-b276-11e9-82de-f8999f0248de.png) 
compared to dev 
![image](https://user-images.githubusercontent.com/14948338/62120645-dc18ab00-b276-11e9-8d28-4b9bbfe6c48e.png)


2) Stars and number of reviews next to stars also better formatted (centered and in-line now) 
![image](https://user-images.githubusercontent.com/14948338/62120698-f18dd500-b276-11e9-9391-e5405862181d.png)
compared to dev 
![image](https://user-images.githubusercontent.com/14948338/62120671-e6d34000-b276-11e9-86aa-1d01ff2dbeef.png)

3) Space is properly allocated to columns (columns with entries of larger character counts get more width-space while entries with lower counts get less)
![image](https://user-images.githubusercontent.com/14948338/62120801-2ac64500-b277-11e9-957f-b0a3da469a30.png)
vs dev
![image](https://user-images.githubusercontent.com/14948338/62120821-3a458e00-b277-11e9-93ff-c9da6d96fe2d.png)

4)If no studies are found when searching, format of error message doesn't exceed the table's height: 
![image](https://user-images.githubusercontent.com/14948338/62121001-94deea00-b277-11e9-8841-6e7eb6f93f3c.png)
vs dev
![image](https://user-images.githubusercontent.com/14948338/62121016-9c9e8e80-b277-11e9-9ff3-a589c0399134.png)

5)Also fixed pesky bug on bigger screens where table row would overflow out of table (can't show because my screen is small but no harm done here)
